### PR TITLE
Add missing Maven artifact blocks

### DIFF
--- a/market/doc-factory/meta.json
+++ b/market/doc-factory/meta.json
@@ -1,28 +1,37 @@
 {
-	"$schema": "https://json-schema.axonivy.com/market/10.0.0/meta.json",
-	"id": "doc-factory",
-	"name": "DocFactory",
-	"description": "Based on Aspose technology the DocFactory creates any type of document out of your process data.",
-	"type": "util",
-	"platformReview": "4.5",
-	"sourceUrl": "https://github.com/nqhoan-org/doc-factory",
-	"language": "English",
-	"industry": "Cross-Industry",
-	"tags": ["document"],
-	"validate": true,
-	"mavenArtifacts": [
-		{
-			"name": "DocFactory Product",
-			"groupId": "com.axonivy.utils.docfactory",
-			"artifactId": "doc-factory-product",
-			"type": "zip"
-		},
-		{
-			"name": "DocFactory Documentation",
-			"groupId": "com.axonivy.utils.docfactory",
-			"artifactId": "doc-factory-doc",
-			"type": "zip",
-			"doc": true
-		}
-	]	
+    "$schema" : "https://json-schema.axonivy.com/market/10.0.0/meta.json",
+    "id" : "doc-factory",
+    "name" : "DocFactory",
+    "description" : "Based on Aspose technology the DocFactory creates any type of document out of your process data.",
+    "type" : "util",
+    "platformReview" : "4.5",
+    "sourceUrl" : "https://github.com/nqhoan-org/doc-factory",
+    "language" : "English",
+    "industry" : "Cross-Industry",
+    "tags" : [
+        "document"
+    ],
+    "validate" : true,
+    "mavenArtifacts" : [
+        {
+            "name" : "DocFactory Product",
+            "groupId" : "com.axonivy.utils.docfactory",
+            "artifactId" : "doc-factory-product",
+            "type" : "zip"
+        },
+        {
+            "name" : "DocFactory Documentation",
+            "groupId" : "com.axonivy.utils.docfactory",
+            "artifactId" : "doc-factory-doc",
+            "type" : "zip",
+            "doc" : true
+        },
+        {
+            "key" : "doc-factory",
+            "name" : "DocFactory Demo App",
+            "groupId" : "doc-factory-modules",
+            "artifactId" : "doc-factory-demo-app",
+            "type" : "zip"
+        }
+    ]
 }


### PR DESCRIPTION
This PR adds missing Maven artifact blocks to all `meta.json` files in the repository.